### PR TITLE
Fix build in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "uber-direct",
   "version": "0.1.0",
   "description": "The Uber Direct JS SDK is an npm package that allows developers to easily interact with the Uber Direct API.",
-  "main": "index.js",
+  "main": "dist/index.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc",


### PR DESCRIPTION
The `npm run prepare` function will run and create the dist folder. We need to make sure we define the types/main in package.json.

See https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish.