### PR TITLE
Fix package.json: Point to the compiled JavaScript file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "uber-direct",
   "version": "0.1.2",
   "description": "The Uber Direct JS SDK is an npm package that allows developers to easily interact with the Uber Direct API.",
-  "main": "dist/index.ts",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
I tested this locally with the samples repo, copying over the dist folder to verify.

```
➜  js git:(mager/cleanup_dist) ✗ cp -r ../../uber-direct-sdk/dist node_modules/uber-direct
➜  js git:(mager/cleanup_dist) ✗ node ./auth/basic.js
Your access token is: REDACTED
```