### PR TITLE
Add sandbox environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,34 @@ const deliveriesClient = createDeliveriesClient(token);
 
 You can use this client for subsequent requests.
 
+### Using Sandbox Environment
+
+Both the Organizations and Deliveries clients support connecting to the Uber sandbox environment for testing purposes. By default, clients connect to the production API (`api.uber.com`). You can specify the sandbox environment by passing options to the client constructors:
+
+#### Deliveries Client with Sandbox
+
+```js
+import { getAccessToken } from 'uber-direct/auth';
+import { createDeliveriesClient } from 'uber-direct/deliveries';
+
+const token = await getAccessToken();
+const deliveriesClient = createDeliveriesClient(token, customerId, {
+  environment: 'sandbox'
+});
+```
+
+#### Organizations Client with Sandbox
+
+```js
+import { getAccessToken } from 'uber-direct/auth';
+import { createOrganizationsClient } from 'uber-direct/organizations';
+
+const token = await getAccessToken();
+const organizationsClient = createOrganizationsClient(token, {
+  environment: 'sandbox'
+});
+```
+
 #### Create Quote
 
 ```js

--- a/src/__tests__/deliveries/index.test.ts
+++ b/src/__tests__/deliveries/index.test.ts
@@ -19,7 +19,7 @@ describe('DeliveriesClient', () => {
   });
 
   it('success - should return an instance of DeliveriesClient if customerID is passed in', () => {
-    const deliveriesClient = createDeliveriesClient(accessToken, { customerId });
+    const deliveriesClient = createDeliveriesClient(accessToken, customerId);
 
     expect(deliveriesClient).toBeDefined();
     expect(deliveriesClient.accessToken).toEqual(accessToken);
@@ -30,8 +30,7 @@ describe('DeliveriesClient', () => {
   });
 
   it('success - should use sandbox URL when environment is set to sandbox', () => {
-    const deliveriesClient = createDeliveriesClient(accessToken, {
-      customerId,
+    const deliveriesClient = createDeliveriesClient(accessToken, customerId, {
       environment: 'sandbox'
     });
 
@@ -42,9 +41,7 @@ describe('DeliveriesClient', () => {
   });
 
   it('success - should use production URL by default', () => {
-    const deliveriesClient = createDeliveriesClient(accessToken, {
-      customerId
-    });
+    const deliveriesClient = createDeliveriesClient(accessToken, customerId);
 
     expect(deliveriesClient).toBeDefined();
     expect(deliveriesClient.baseURL).toEqual(

--- a/src/__tests__/deliveries/index.test.ts
+++ b/src/__tests__/deliveries/index.test.ts
@@ -19,11 +19,34 @@ describe('DeliveriesClient', () => {
   });
 
   it('success - should return an instance of DeliveriesClient if customerID is passed in', () => {
-    const deliveriesClient = createDeliveriesClient(accessToken, customerId);
+    const deliveriesClient = createDeliveriesClient(accessToken, { customerID: customerId });
 
     expect(deliveriesClient).toBeDefined();
     expect(deliveriesClient.accessToken).toEqual(accessToken);
     expect(deliveriesClient.customerID).toEqual(customerId);
+    expect(deliveriesClient.baseURL).toEqual(
+      `https://api.uber.com/v1/customers/${customerId}`
+    );
+  });
+
+  it('success - should use sandbox URL when environment is set to sandbox', () => {
+    const deliveriesClient = createDeliveriesClient(accessToken, {
+      customerID: customerId,
+      environment: 'sandbox'
+    });
+
+    expect(deliveriesClient).toBeDefined();
+    expect(deliveriesClient.baseURL).toEqual(
+      `https://api-sandbox.uber.com/v1/customers/${customerId}`
+    );
+  });
+
+  it('success - should use production URL by default', () => {
+    const deliveriesClient = createDeliveriesClient(accessToken, {
+      customerID: customerId
+    });
+
+    expect(deliveriesClient).toBeDefined();
     expect(deliveriesClient.baseURL).toEqual(
       `https://api.uber.com/v1/customers/${customerId}`
     );

--- a/src/__tests__/deliveries/index.test.ts
+++ b/src/__tests__/deliveries/index.test.ts
@@ -37,7 +37,7 @@ describe('DeliveriesClient', () => {
 
     expect(deliveriesClient).toBeDefined();
     expect(deliveriesClient.baseURL).toEqual(
-      `https://api-sandbox.uber.com/v1/customers/${customerId}`
+      `https://sandbox-api.uber.com/v1/customers/${customerId}`
     );
   });
 

--- a/src/__tests__/deliveries/index.test.ts
+++ b/src/__tests__/deliveries/index.test.ts
@@ -19,7 +19,7 @@ describe('DeliveriesClient', () => {
   });
 
   it('success - should return an instance of DeliveriesClient if customerID is passed in', () => {
-    const deliveriesClient = createDeliveriesClient(accessToken, { customerID: customerId });
+    const deliveriesClient = createDeliveriesClient(accessToken, { customerId });
 
     expect(deliveriesClient).toBeDefined();
     expect(deliveriesClient.accessToken).toEqual(accessToken);
@@ -31,7 +31,7 @@ describe('DeliveriesClient', () => {
 
   it('success - should use sandbox URL when environment is set to sandbox', () => {
     const deliveriesClient = createDeliveriesClient(accessToken, {
-      customerID: customerId,
+      customerId,
       environment: 'sandbox'
     });
 
@@ -43,7 +43,7 @@ describe('DeliveriesClient', () => {
 
   it('success - should use production URL by default', () => {
     const deliveriesClient = createDeliveriesClient(accessToken, {
-      customerID: customerId
+      customerId
     });
 
     expect(deliveriesClient).toBeDefined();

--- a/src/__tests__/organizations/index.test.ts
+++ b/src/__tests__/organizations/index.test.ts
@@ -7,4 +7,29 @@ describe('OrganizationsClient', () => {
 
     expect(organizationsClient).toBeDefined();
   });
+
+  it('success - should use production URL by default', () => {
+    const organizationsClient = createOrganizationsClient(accessToken);
+
+    expect(organizationsClient).toBeDefined();
+    expect(organizationsClient.baseURL).toEqual('https://api.uber.com/v1/direct');
+  });
+
+  it('success - should use sandbox URL when environment is set to sandbox', () => {
+    const organizationsClient = createOrganizationsClient(accessToken, {
+      environment: 'sandbox'
+    });
+
+    expect(organizationsClient).toBeDefined();
+    expect(organizationsClient.baseURL).toEqual('https://api-sandbox.uber.com/v1/direct');
+  });
+
+  it('success - should use production URL when environment is set to production', () => {
+    const organizationsClient = createOrganizationsClient(accessToken, {
+      environment: 'production'
+    });
+
+    expect(organizationsClient).toBeDefined();
+    expect(organizationsClient.baseURL).toEqual('https://api.uber.com/v1/direct');
+  });
 });

--- a/src/__tests__/organizations/index.test.ts
+++ b/src/__tests__/organizations/index.test.ts
@@ -21,7 +21,7 @@ describe('OrganizationsClient', () => {
     });
 
     expect(organizationsClient).toBeDefined();
-    expect(organizationsClient.baseURL).toEqual('https://api-sandbox.uber.com/v1/direct');
+    expect(organizationsClient.baseURL).toEqual('https://sandbox-api.uber.com/v1/direct');
   });
 
   it('success - should use production URL when environment is set to production', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,6 @@ export interface ClientOptions {
 
 export const getBaseURL = (environment: Environment = 'production'): string => {
   return environment === 'sandbox'
-    ? 'https://api-sandbox.uber.com'
+    ? 'https://sandbox-api.uber.com'
     : 'https://api.uber.com';
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,16 @@
+export type Environment = 'production' | 'sandbox';
+
+export interface ClientOptions {
+  /**
+   * The environment to use for API requests.
+   * - 'production': api.uber.com (default)
+   * - 'sandbox': api-sandbox.uber.com
+   */
+  environment?: Environment;
+}
+
+export const getBaseURL = (environment: Environment = 'production'): string => {
+  return environment === 'sandbox'
+    ? 'https://api-sandbox.uber.com'
+    : 'https://api.uber.com';
+};

--- a/src/deliveries/index.ts
+++ b/src/deliveries/index.ts
@@ -13,7 +13,7 @@ export interface DeliveriesClientOptions extends ClientOptions {
    * The Uber Direct customer ID. If not provided, falls back to
    * the UBER_DIRECT_CUSTOMER_ID environment variable.
    */
-  customerID?: string;
+  customerId?: string;
 }
 
 export class DeliveriesClient {
@@ -24,7 +24,7 @@ export class DeliveriesClient {
   constructor(accessToken: string, options?: DeliveriesClientOptions) {
     this.accessToken = accessToken;
 
-    const cusID = options?.customerID || process.env.UBER_DIRECT_CUSTOMER_ID;
+    const cusID = options?.customerId || process.env.UBER_DIRECT_CUSTOMER_ID;
 
     if (!cusID) {
       throw new Error(

--- a/src/deliveries/index.ts
+++ b/src/deliveries/index.ts
@@ -8,23 +8,15 @@ import type {
 import { fetchData, makeQueryString } from '../utils';
 import { getBaseURL, type ClientOptions } from '../config';
 
-export interface DeliveriesClientOptions extends ClientOptions {
-  /**
-   * The Uber Direct customer ID. If not provided, falls back to
-   * the UBER_DIRECT_CUSTOMER_ID environment variable.
-   */
-  customerId?: string;
-}
-
 export class DeliveriesClient {
   accessToken: string;
   baseURL: string;
   customerID: string;
 
-  constructor(accessToken: string, options?: DeliveriesClientOptions) {
+  constructor(accessToken: string, customerId?: string, options?: ClientOptions) {
     this.accessToken = accessToken;
 
-    const cusID = options?.customerId || process.env.UBER_DIRECT_CUSTOMER_ID;
+    const cusID = customerId || process.env.UBER_DIRECT_CUSTOMER_ID;
 
     if (!cusID) {
       throw new Error(
@@ -99,7 +91,8 @@ export class DeliveriesClient {
 
 export const createDeliveriesClient = (
   accessToken: string,
-  options?: DeliveriesClientOptions
+  customerId?: string,
+  options?: ClientOptions
 ) => {
-  return new DeliveriesClient(accessToken, options);
+  return new DeliveriesClient(accessToken, customerId, options);
 };

--- a/src/deliveries/index.ts
+++ b/src/deliveries/index.ts
@@ -6,16 +6,25 @@ import type {
   UpdateDeliveryReq,
 } from './types';
 import { fetchData, makeQueryString } from '../utils';
+import { getBaseURL, type ClientOptions } from '../config';
+
+export interface DeliveriesClientOptions extends ClientOptions {
+  /**
+   * The Uber Direct customer ID. If not provided, falls back to
+   * the UBER_DIRECT_CUSTOMER_ID environment variable.
+   */
+  customerID?: string;
+}
 
 export class DeliveriesClient {
   accessToken: string;
   baseURL: string;
   customerID: string;
 
-  constructor(accessToken: string, customerID?: string) {
+  constructor(accessToken: string, options?: DeliveriesClientOptions) {
     this.accessToken = accessToken;
 
-    const cusID = customerID || process.env.UBER_DIRECT_CUSTOMER_ID;
+    const cusID = options?.customerID || process.env.UBER_DIRECT_CUSTOMER_ID;
 
     if (!cusID) {
       throw new Error(
@@ -23,7 +32,8 @@ export class DeliveriesClient {
       );
     }
     this.customerID = cusID;
-    this.baseURL = `https://api.uber.com/v1/customers/${this.customerID}`;
+    const baseURL = getBaseURL(options?.environment);
+    this.baseURL = `${baseURL}/v1/customers/${this.customerID}`;
   }
 
   async createQuote(req: DeliveryQuoteReq) {
@@ -89,7 +99,7 @@ export class DeliveriesClient {
 
 export const createDeliveriesClient = (
   accessToken: string,
-  customerID?: string
+  options?: DeliveriesClientOptions
 ) => {
-  return new DeliveriesClient(accessToken, customerID);
+  return new DeliveriesClient(accessToken, options);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,4 @@
 export { getAccessToken } from './auth';
-export {
-  DeliveriesClient,
-  createDeliveriesClient,
-  type DeliveriesClientOptions,
-} from './deliveries';
+export { DeliveriesClient, createDeliveriesClient } from './deliveries';
 export { OrganizationsClient, createOrganizationsClient } from './organizations';
 export { type ClientOptions, type Environment } from './config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export { getAccessToken } from './auth';
-export { DeliveriesClient, createDeliveriesClient } from './deliveries';
+export {
+  DeliveriesClient,
+  createDeliveriesClient,
+  type DeliveriesClientOptions,
+} from './deliveries';
 export { OrganizationsClient, createOrganizationsClient } from './organizations';
+export { type ClientOptions, type Environment } from './config';

--- a/src/organizations/index.ts
+++ b/src/organizations/index.ts
@@ -1,14 +1,16 @@
 import type { CreateOrgReq } from './types';
 import type { InviteMemberReq } from './types';
 import { fetchData } from '../utils';
+import { getBaseURL, type ClientOptions } from '../config';
 
 export class OrganizationsClient {
   accessToken: string;
   baseURL: string;
 
-  constructor(accessToken: string) {
+  constructor(accessToken: string, options?: ClientOptions) {
     this.accessToken = accessToken;
-    this.baseURL = 'https://api.uber.com/v1/direct';
+    const baseURL = getBaseURL(options?.environment);
+    this.baseURL = `${baseURL}/v1/direct`;
   }
 
   async createOrganization(req: CreateOrgReq) {
@@ -26,6 +28,9 @@ export class OrganizationsClient {
 
 }
 
-export const createOrganizationsClient = (accessToken: string) => {
-  return new OrganizationsClient(accessToken);
+export const createOrganizationsClient = (
+  accessToken: string,
+  options?: ClientOptions
+) => {
+  return new OrganizationsClient(accessToken, options);
 };


### PR DESCRIPTION
Adds optional `environment` parameter to SDK clients, allowing developers to connect to the Uber sandbox environment (`sandbox-api.uber.com`) for testing instead of production.